### PR TITLE
Link to vim-ruby-xmpfilter in the readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -66,7 +66,7 @@ Editor Integration
 * [sublime-text-2-seeing-is-believing](https://github.com/JoshCheek/sublime-text-2-seeing-is-believing)
 * [TextMate 1](https://github.com/JoshCheek/text_mate_1-seeing-is_believing)
 * [TextMate 2](https://github.com/JoshCheek/text_mate_2-seeing-is_believing)
-* [vim-seeing-is-believing](https://github.com/hwartig/vim-seeing-is-believing)
+* [vim-ruby-xmpfilter](https://github.com/t9md/vim-ruby-xmpfilter) (has support for `seeing_is_believing`)
 
 Emacs Integration
 =================


### PR DESCRIPTION
The plugin `vim-seeing-is-believing` doesn't have one crucial feature: to apply `seeing_is_believing` to the whole file, without there needing to be any markers.

And `vim-ruby-xmpfilter` added the support for `seeing_is_believing`.
