### PR TITLE
emacs integration should preserve point

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -88,8 +88,10 @@ Add this function to your Emacs configuration:
 of seeing_is_believing."
   (interactive)
   (let ((beg (if (region-active-p) (region-beginning) (point-min)))
-        (end (if (region-active-p) (region-end) (point-max))))
-    (shell-command-on-region beg end "seeing_is_believing" nil 'replace)))
+        (end (if (region-active-p) (region-end) (point-max)))
+        (origin (point)))
+    (shell-command-on-region beg end "seeing_is_believing" nil 'replace)
+    (goto-char origin)))
 ```
 
 You can now call `seeing-is-believing` to replace the current region


### PR DESCRIPTION
The current integration can cause the point to be moved, for example to the top of the file if the entire file is being annotated. This change returns point to its original position after annotation. I didn't use `save-excursion` because it's defeated by using the `replace` argument of `shell-command-on-region` according to http://stackoverflow.com/a/8116695.