### PR TITLE
gemspec: drop rubyforge_project, it is EOL

### DIFF
--- a/seeing_is_believing.gemspec
+++ b/seeing_is_believing.gemspec
@@ -12,8 +12,6 @@ Gem::Specification.new do |s|
   s.description = %q{Records the results of every line of code in your file (intended to be like xmpfilter), inspired by Bret Victor's JavaScript example in his talk "Inventing on Principle"}
   s.license     = "WTFPL"
 
-  s.rubyforge_project = "seeing_is_believing"
-
   s.files         = `git ls-files`.split("\n") - ['docs/seeing is believing.psd'] # remove psd b/c it boosts the gem size from 50kb to 20mb O.o
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }


### PR DESCRIPTION
The RubyGems gemspec property `rubyforge_project` has been removed without a replacement.