### PR TITLE
Support parser v3

### DIFF
--- a/seeing_is_believing.gemspec
+++ b/seeing_is_believing.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency             "parser",      "~> 2.7"
+  s.add_dependency             "parser",      ">= 2.7", "< 4"
   s.add_dependency             "childprocess","~> 4.1"
   s.add_dependency             "ffi",         "~> 1.15"
 


### PR DESCRIPTION
It doesn't seem there's any critical breaking changes in v3:

https://github.com/whitequark/parser/blob/master/CHANGELOG.md#v3000-2020-12-25