### PR TITLE
zenspider  frozen strings

### DIFF
--- a/lib/seeing_is_believing.rb
+++ b/lib/seeing_is_believing.rb
@@ -15,7 +15,7 @@ class SeeingIsBelieving
     predicate(:local_cwd)         { false }
     attribute(:filename)          { nil }
     attribute(:encoding)          { nil }
-    attribute(:stdin)             { "" }
+    attribute(:stdin)             { +"" }
     attribute(:require_files)     { ['seeing_is_believing/the_matrix'] }
     attribute(:load_path_dirs)    { [File.realpath(__dir__)] }
     attribute(:timeout_seconds)   { 0 }

--- a/lib/seeing_is_believing/binary/annotate_end_of_file.rb
+++ b/lib/seeing_is_believing/binary/annotate_end_of_file.rb
@@ -17,8 +17,8 @@ class SeeingIsBelieving
       end
 
       def stdout_ouptut_for(results, options)
-        return '' unless results.has_stdout?
-        output = "\n"
+        return +'' unless results.has_stdout?
+        output = +"\n"
         results.stdout.each_line do |line|
           output << FormatComment.call(0, options[:markers][:stdout][:prefix], line.chomp, options) << "\n"
         end
@@ -27,7 +27,7 @@ class SeeingIsBelieving
 
       def stderr_ouptut_for(results, options)
         return '' unless results.has_stderr?
-        output = "\n"
+        output = +"\n"
         results.stderr.each_line do |line|
           output << FormatComment.call(0, options[:markers][:stderr][:prefix], line.chomp, options) << "\n"
         end
@@ -37,7 +37,7 @@ class SeeingIsBelieving
       def exception_output_for(results, options)
         return '' unless results.has_exception?
         exception_marker = options[:markers][:exception][:prefix]
-        output = ""
+        output = +""
         results.exceptions.each do |exception|
           output << "\n"
           output << FormatComment.new(0, exception_marker, exception.class_name, options).call << "\n"

--- a/lib/seeing_is_believing/binary/annotate_every_line.rb
+++ b/lib/seeing_is_believing/binary/annotate_every_line.rb
@@ -37,7 +37,7 @@ class SeeingIsBelieving
               end
               FormatComment.call(line.size, value_prefix, result, options)
             else
-              ''
+              +''
             end
           end
 

--- a/lib/seeing_is_believing/binary/annotate_marked_lines.rb
+++ b/lib/seeing_is_believing/binary/annotate_marked_lines.rb
@@ -57,7 +57,7 @@ class SeeingIsBelieving
               if    should_inspect && should_pp then "#{pp}#{inspect}"
               elsif should_inspect              then inspect
               elsif should_pp                   then pp
-              else                                   ""
+              else                                   +""
               end
             },
             after_each:  -> line_number {
@@ -74,7 +74,7 @@ class SeeingIsBelieving
               if    should_inspect && should_pp then "#{inspect}#{pp}"
               elsif should_inspect              then inspect
               elsif should_pp                   then pp
-              else                                   ""
+              else                                   +""
               end
             }
         end

--- a/lib/seeing_is_believing/binary/data_structures.rb
+++ b/lib/seeing_is_believing/binary/data_structures.rb
@@ -20,7 +20,7 @@ class SeeingIsBelieving
         }
         string =~ %r{\A/(.*)/([mxi]*)\Z}
         body  = $1 || string
-        flags = ($2 || "").each_char.inject(0) { |bits, flag| bits | flag_to_bit[flag] }
+        flags = ($2 || +"").each_char.inject(0) { |bits, flag| bits | flag_to_bit[flag] }
         Regexp.new body, flags
       end
 

--- a/lib/seeing_is_believing/binary/rewrite_comments.rb
+++ b/lib/seeing_is_believing/binary/rewrite_comments.rb
@@ -45,7 +45,7 @@ class SeeingIsBelieving
             whitespace_col:   whitespace_col-line_begin_col,
             whitespace:       code.raw[whitespace_col...nextline_begin_col]||"",
             text_col:         nextline_begin_col-line_begin_col,
-            text:             "",
+            text:             +"",
             full_range:       whitespace_range,
             whitespace_range: whitespace_range,
             comment_range:    comment_range

--- a/lib/seeing_is_believing/compatibility.rb
+++ b/lib/seeing_is_believing/compatibility.rb
@@ -13,7 +13,7 @@ is_v2_0 && begin
     refine String do
       def scrub(char=nil, &block)
         char && block = lambda { |c| char }
-        each_char.inject("") do |new_str, char|
+        each_char.inject(+"") do |new_str, char|
           if char.valid_encoding?
             new_str << char
           else

--- a/lib/seeing_is_believing/debugger.rb
+++ b/lib/seeing_is_believing/debugger.rb
@@ -6,6 +6,7 @@ class SeeingIsBelieving
     def initialize(options={})
       @coloured = options[:colour]
       @stream   = options[:stream]
+      @stream = +@stream if @stream.is_a?(String) && @stream.frozen?
     end
 
     Null = new stream: nil

--- a/lib/seeing_is_believing/event_stream/handlers/debug.rb
+++ b/lib/seeing_is_believing/event_stream/handlers/debug.rb
@@ -9,7 +9,7 @@ class SeeingIsBelieving
         def initialize(debugger, handler)
           @debugger   = debugger
           @handler    = handler
-          @seen       = ""
+          @seen       = +""
           @line_width = 150 # debugger is basically for me, so giving it a nice wide width
           @name_width = 20
           @attr_width = @line_width - @name_width

--- a/lib/seeing_is_believing/event_stream/producer.rb
+++ b/lib/seeing_is_believing/event_stream/producer.rb
@@ -152,7 +152,7 @@ class SeeingIsBelieving
             loop do
               to_publish = queue.shift
               break if :break == to_publish
-              resultstream << (to_publish << "\n")
+              resultstream << to_publish << "\n"
             end
           rescue IOError, Errno::EPIPE
             queue.clear

--- a/lib/seeing_is_believing/result.rb
+++ b/lib/seeing_is_believing/result.rb
@@ -10,8 +10,8 @@ class SeeingIsBelieving
     end
 
     def initialize
-      self.stdout     = ''
-      self.stderr     = ''
+      self.stdout     = +''
+      self.stderr     = +''
       self.exceptions = []
     end
 

--- a/spec/binary/comment_lines_spec.rb
+++ b/spec/binary/comment_lines_spec.rb
@@ -4,6 +4,7 @@ require 'seeing_is_believing/binary/comment_lines'
 RSpec.describe SeeingIsBelieving::Binary::CommentLines, 'passes in the each commentable line and the line number, and adds the returned text (whitespace+comment) to the end' do
   def call(code, &block)
     return described_class.call(code, &block) if code.end_with? "\n"
+    code = +code
     code << "\n"
     described_class.call(code, &block).chomp
   end

--- a/spec/binary/format_comment_spec.rb
+++ b/spec/binary/format_comment_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe SeeingIsBelieving::Binary::FormatComment do
   end
 
   def assert_printed(c, printed)
-    c = c.force_encoding 'utf-8'
+    c = (+c).force_encoding 'utf-8'
     result = result_for 0, '', c
     expect(result).to eq printed
     expect(result.encoding).to eq Encoding::UTF_8

--- a/spec/event_stream_spec.rb
+++ b/spec/event_stream_spec.rb
@@ -96,7 +96,7 @@ module SeeingIsBelieving::EventStream
       end
 
       def ascii8bit(str)
-        str.force_encoding Encoding::ASCII_8BIT
+        (+str).force_encoding Encoding::ASCII_8BIT
       end
 
       it 'force encodes the message to UTF8 when it can\'t validly transcode' do
@@ -307,7 +307,7 @@ module SeeingIsBelieving::EventStream
         end
 
         it 'can deal with results of inspect that have singleton methods' do
-          str = "a string"
+          str = +"a string"
           def str.inspect() self end
           producer.record_result :type, 1, str
           expect(consumer.call.inspected).to eq str
@@ -684,7 +684,7 @@ module SeeingIsBelieving::EventStream
     require 'seeing_is_believing/event_stream/handlers/stream_json_events'
     describe Handlers::StreamJsonEvents do
       it 'writes each event\'s json representation to the stream' do
-        stream  = ""
+        stream  = +"" # TODO: push unfreezing upstream but fix final expect
         handler = described_class.new stream
 
         handler.call Events::Stdout.new(value: "abc")
@@ -712,7 +712,7 @@ module SeeingIsBelieving::EventStream
     end
 
     describe Handlers::Debug do
-      let(:stream)          { "" }
+      let(:stream)          { +"" }
       let(:events_seen)     { [] }
       let(:debugger)        { SeeingIsBelieving::Debugger.new stream: stream }
       let(:parent_observer) { lambda { |event| events_seen << event } }

--- a/spec/hash_struct_spec.rb
+++ b/spec/hash_struct_spec.rb
@@ -31,10 +31,10 @@ RSpec.describe SeeingIsBelieving::HashStruct do
       end
 
       specify 'the block value is not cached' do
-        klass.attribute(:a,   "a" ).new.a << "-modified"
+        klass.attribute(:a,   +"a" ).new.a << "-modified"
         eq! "a-modified", klass.new.a
 
-        klass.attribute(:b) { "b" }.new.b << "-modified"
+        klass.attribute(:b) { +"b" }.new.b << "-modified"
         eq! "b",          klass.new.b
       end
 
@@ -405,7 +405,7 @@ RSpec.describe SeeingIsBelieving::HashStruct do
       it 'is enumerable, iterating over each attribute(as symbol)/value pair' do
         klass.attributes(a: 1, b: 2)
         eq! [[:a, 1], [:b, 2]], klass.new.to_a
-        eq! "a1b2", klass.new.each.with_object("") { |(k, v), s| s << "#{k}#{v}" }
+        eq! "a1b2", klass.new.each.with_object(+"") { |(k, v), s| s << "#{k}#{v}" }
       end
     end
 

--- a/spec/seeing_is_believing_spec.rb
+++ b/spec/seeing_is_believing_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe SeeingIsBelieving do
   end
 
   it 'records the value immediately, so that it is correct even if the result is mutated' do
-    expect(values_for("a = 'a'\na << 'b'")).to eq [['"a"'], ['"ab"']]
+    expect(values_for("a = +'a'\na << 'b'")).to eq [['"a"'], ['"ab"']]
   end
 
   it 'records each value when a line is evaluated multiple times' do
@@ -1038,7 +1038,7 @@ RSpec.describe SeeingIsBelieving do
       result = executes_without_error!('
          # producer
          Hash            = "fake Hash"
-         String          = "fake String"
+         String          = +"fake String"
          class << String
            undef ===
          end


### PR DESCRIPTION
This _should be_ a commit that cleans up and fixes all frozen-string errors. I get these because I have `export RUBYOPT=--enable-frozen-string-literal`... this can be further helped (but slower to run) adding `--debug=frozen-string-literal` to that var.

In MOST cases, I tried to push fixes into lib but some specs were modifying strings they were creating so fixes wound up there. 

I think there is one case where I think the fix should be pushed up to lib but the spec as written was expecting modification of a local string. I left it as the "obvious" fix to the `expect` line didn't work for some reason.